### PR TITLE
fix - add the GH_TOKEN as a shell variable to the .env file

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 # Authentication
-GH_TOKEN=
+GH_TOKEN=${GH_TOKEN}
 
 # Branches
 TMS_BRANCH=main


### PR DESCRIPTION
Add the GH_TOKEN shell variable to the .env file so that the variable can be read from the shell automatically if it had been created there as the "GH_TOKEN" environment variable.

![image](https://github.com/frmscoe/Full-Stack-Docker-Tazama/assets/123470803/69c81637-313e-424e-849b-3a4233364038)
