### PR TITLE
docs: replace crsp with ed

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ GH_TOKEN=${GH_TOKEN}
 
 # Branches
 TMS_BRANCH=main
-CRSP_BRANCH=main
+ED_BRANCH=main
 TP_BRANCH=main
 TADP_BRANCH=main
 RULE_901_BRANCH=main
@@ -137,14 +137,14 @@ cd Full-Stack-Docker-Tazama
 Execute the following command to deploy the core processors:
 
 ```
-docker compose up -d tms crsp tp tadp
+docker compose up -d tms ed tp tadp
 ```
 
 
 This command will install:
 
  - The Transaction Monitoring Service API at `<https://localhost:5000>`, where messages will be sent for evaluation. 
- - The Channel Router and Setup Processor that will handle message routing based on the network map
+ - The Event Director that will handle message routing based on the network map
  - The Typology Processor that will summarise rule results into scenarios according to invidual typology configurations
  - The Transaction Aggregation and Decisioning Processor that will wrap up the evaluation of a transaction and publish any alerts for breached typologies
 
@@ -210,7 +210,7 @@ List of \<services\>
 - redis  
 - nats  
 - tms   
-- crsp  
+- ed  
 - tadp  
 - tp  
 - rule-901  


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
 - replaced `crsp` with `ed`

## Why are we doing this?
 - Channel concept has been removed from the system and CRSP has been replaced with ED

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [x] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done
