### PR TITLE
fix: change event-director context

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -77,7 +77,7 @@ services:
   # EVENT DIRECTOR
   ed:
     build:
-      context: https://github.com/frmscoe/channel-router-setup-processor.git#${ED_BRANCH}
+      context: https://github.com/frmscoe/event-director.git#${ED_BRANCH}
       args:
         - GH_TOKEN
     env_file:


### PR DESCRIPTION
## What did we change?
Context Git URL for Event Director

## Why are we doing this?
CRSP was renamed

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [x] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done
